### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -19,4 +19,4 @@ exports.TokenStorage = require('./TokenStorage');
  * @memberOf util.prototype
  * @return {string} A generated version 4 UUID.
  */
-exports.uuid = require('node-uuid').v4;
+exports.uuid = require('uuid').v4;

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "core-js": "^2.4.1",
     "crypto-js": "^3.1.6",
     "glob": "^7.0.6",
-    "node-uuid": "^1.4.7",
     "rimraf": "^2.5.4",
     "rxjs": "^5.0.0-rc.2",
     "simple-git": "^1.62.0",
+    "uuid": "^3.0.0",
     "validator": "^4.9.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.