### PR TITLE
Feature/deploy incremental

### DIFF
--- a/cli/deploy.js
+++ b/cli/deploy.js
@@ -8,16 +8,22 @@ const path = require('path');
 const readline = require('readline');
 const crypto = require('crypto');
 
+
+let IS_TTY = process.stdout.isTTY;
+
 module.exports = function(args) {
+
+  console.log('?',args.cleanUp)
+
   return account.login(args).then((db) => {
     let promises = []
     if (!args.code && !args.files || args.code && args.files) {
-      promises.push(deployFiles(db, args.bucketPath, args.fileDir, args.fileGlob))
+      promises.push(deployFiles(db, args.bucketPath, args.fileDir, args.fileGlob, args.cleanUp))
       promises.push(deployCode(db, args.codeDir))
     } else if (args.code) {
       promises.push(deployCode(db, args.codeDir));
     } else if (args.files) {
-      promises.push(deployFiles(db, args.bucketPath, args.fileDir, args.fileGlob));
+      promises.push(deployFiles(db, args.bucketPath, args.fileDir, args.fileGlob, args.cleanUp));
     }
     if (args.schema) {
       promises.push(schema.uploadSchema(db))
@@ -26,7 +32,7 @@ module.exports = function(args) {
   });
 };
 
-function deployFiles(db, path, cwd, pattern) {
+function deployFiles(db, path, cwd, pattern, cleanUp) {
   while (path.length && path.charAt(0) === '/')
     path = path.substring(1);
 
@@ -43,7 +49,7 @@ function deployFiles(db, path, cwd, pattern) {
       if (er)
         reject(er);
       else
-        resolve(uploadFiles(db, path, files, cwd));
+        resolve(uploadFiles(db, path, files, cwd, cleanUp));
     });
   }).then((result) => {
     if (result && result.length > 0) {
@@ -137,66 +143,192 @@ function uploadCode(db, name, codePath) {
   }).then(() => {
     console.log(`Module ${moduleName} deployed.`);
   });
+
 }
 
-function uploadFiles(db, bucket, files, cwd) {
-  let isTty = process.stdout.isTTY;
-  let index = 0;
+// ####
 
-  let uploads = [];
-  for (let i = 0; i < 10 && i < files.length; ++i) {
-    uploads.push(upload());
-  }
-
-  if (!isTty) {
-    console.log(`Uploading ${files.length} files.`)
-  }
-
-  return Promise.all(uploads);
-
-  function upload() {
-    if (index < files.length) {
-      if (isTty) {
-        if (index > 0) {
-          readline.clearLine(process.stdout, 0);
-          readline.cursorTo(process.stdout, 0);
-        }
-        process.stdout.write(`Uploading file ${(index + 1)} of ${files.length}`);
-      }
-
-      var file = files[index++];
-
-      if (isTty && index == files.length) {
-        console.log(''); //add a final linebreak
-      }
-
-      return uploadFile(db, bucket, file, cwd).then(upload);
+function listAllFiles(db, dir, start = 0, offset = 1000){
+  return db.File.listFiles(dir, start, offset).then(files => {
+    if (files.length > 0){
+      return listAllFiles(db, dir, files[files.length - 1], offset).then(nextFiles => files.concat(nextFiles))
     }
+    return []
+  })
+}
+
+function getFilesFromBucket(db, dir){
+  return listAllFiles(db, dir).then(files => {
+    return Promise.all(files.map(file => {
+      if (file.isFolder){
+        return getFilesFromBucket(db, file)
+      } else {
+        return Promise.resolve(file)
+      }
+    })).then(files => [].concat.apply([],files))
+  })
+}
+
+function uploadFiles(db, bucket, files, cwd, cleanUpDist) {
+
+  let resolve = getFilesFromBucket(db, bucket)
+
+  resolve = resolve.then(files => runGenerator(Generator(files, function (file, progress){    
+      
+    if (progress > 0) {
+      readline.clearLine(process.stdout, 0);
+      readline.cursorTo(process.stdout, 0);
+    }
+    process.stdout.write(`Prepare Upload ${(Math.round(progress * 100))}%`);
+    
+    if (IS_TTY && progress === 1) {
+        console.log(''); //add a final linebreak
+    }
+
+    return file.loadMetadata().then(() => file);
+  }), 4))
+
+  // exclude files over 5mb, for force upload
+  // TODO: get file hash for >5mb file
+  const MAX_INCREMENTAL_UPLOAD_SIZE = 5242880;
+  resolve = resolve.then(files => files.filter(file => file.size < MAX_INCREMENTAL_UPLOAD_SIZE));
+
+  resolve = resolve.then(files => {
+    const existFileMapping = files.reduce((result, file) => {
+      result.eTag.set(file.eTag, file)
+      result.path.set(file.path, file)
+      return result;
+    }, {
+      eTag: new Map(),
+      path: new Map()
+    });
+    return existFileMapping;
+  })
+
+    
+  resolve = resolve.then(upload(db, bucket, files, cwd));
+    
+  if (cleanUpDist){
+    resolve = resolve.then(cleanUp)
+  }
+  
+  return resolve;
+}
+
+function upload (db, bucket, files, cwd) {
+  return (existFileMapping) => {
+    if (!IS_TTY) {
+      console.log(`Uploading ${files.length} files.`)
+    }
+    const totalCount = files.length;
+    return runGenerator(Generator(files, function (filePath, progress){    
+          
+      if (progress > 0) {
+        readline.clearLine(process.stdout, 0);
+        readline.cursorTo(process.stdout, 0);
+      }
+      // process.stdout.write(`Uploading files ${(Math.round(progress * 100))}%`);
+      process.stdout.write(`Uploading file ${(Math.ceil(progress * totalCount))} of ${totalCount}`);
+
+      if (IS_TTY && progress === 1) {
+          console.log(''); //add a final linebreak
+      }
+
+      return uploadFile(db, bucket, filePath, cwd, existFileMapping).then(() => existFileMapping);
+
+
+    })).then((result) => ({result, existFileMapping}))
   }
 }
 
-const MAX_INCREMENTAL_UPLOAD_SIZE = 5242880;
 
-function uploadFile(db, bucket, filePath, cwd) {
+function cleanUp ({result, existFileMapping})  {
+  const files = Array.from(existFileMapping.path.values());
+
+  if (!IS_TTY) {
+    console.log(`Deleting ${files.length} files.`)
+  }
+
+  return runGenerator(Generator(files, function (file, progress){    
+    if (progress > 0) {
+      readline.clearLine(process.stdout, 0);
+      readline.cursorTo(process.stdout, 0);
+    }
+    process.stdout.write(`Deleting files ${(Math.round(progress * 100))}%`);
+    if (IS_TTY && progress === 1) {
+        console.log(''); //add a final linebreak
+    }
+    return file.delete({force: true});
+  })).then(() => result)
+}
+  
+
+function uploadFile(db, bucket, filePath, cwd, existFileMapping) {
+
   const fullFilePath = path.join(cwd, filePath);
   
-  const existingFile = new db.File({path: `/${bucket}/${filePath}`})
+  const existingFile = existFileMapping.path.get(`/${bucket}/${filePath}`) 
 
-  return existingFile.loadMetadata().catch(() => {
-    return false
-  }).then((exists) => {
-    const stat = fs.statSync(fullFilePath);
-    if (!exists || stat.size >= MAX_INCREMENTAL_UPLOAD_SIZE || getFileHash(fullFilePath) !== existingFile.eTag){      
-      const file = new db.File({path: `/${bucket}/${filePath}`, data: fs.createReadStream(fullFilePath), size: stat.size, type: 'stream'});
-      return file.upload({ force: true }).catch(function(e) {
-        throw new Error(`Failed to upload file ${filePath}: ${e.message}`);
-      });  
-    } else {
-      return Promise.resolve();
-    }
-  })
+  const stat = fs.statSync(fullFilePath);
+
+  existingFile && existFileMapping.path.delete(`/${bucket}/${filePath}`);
+  // exists map has logic for large files (hash)
+  if (!existingFile || getFileHash(fullFilePath) !== existingFile.eTag){       
+    const file = new db.File({path: `/${bucket}/${filePath}`, data: fs.createReadStream(fullFilePath), size: stat.size, type: 'stream'});
+    return file.upload({ force: true }).catch(function(e) {
+      throw new Error(`Failed to upload file ${filePath}: ${e.message}`);
+    });  
+  } else {
+    return Promise.resolve();
+  }
 }
 
 function getFileHash(filepath) {
   return crypto.createHash('md5').update(fs.readFileSync(filepath)).digest("hex");
+}
+
+
+
+function runGenerator(generator, parallel = 2, totalResults = []){
+  return Promise.all(
+    Array(parallel).fill(() => Promise.resolve(generator.next().value || [])).map((next) => next())
+  ).then(results => {
+    results = [].concat.apply([],results);
+    totalResults.push(...results)  
+    if (results.length > 0){
+      return runGenerator(generator, parallel, totalResults)
+    }
+    return totalResults;
+  });
+}
+
+
+// Generator
+
+function* Generator(entries, func) {
+  let count = 0;
+  const totalCount = entries.length;
+  while (entries.length > 0) {
+      yield Promise.resolve(entries.shift()).then((value) => {
+          count++
+          return func(value, count / totalCount);
+      })
+  }
+}
+
+function runGenerator(generator, parallel = 2, totalResults = []) {
+  const run = function (){
+      return Promise.resolve(generator.next().value).then(result => {
+          if (result !== undefined) {                
+              totalResults.push(result)
+              return run()
+          }
+          return totalResults;
+      })
+  };
+  const resolves = []
+  for (let i = 0; i < parallel; i++) {
+      resolves.push(run());
+  }
+  return Promise.all(resolves).then(() => totalResults)
 }

--- a/cli/deploy.js
+++ b/cli/deploy.js
@@ -181,12 +181,12 @@ function uploadFile(db, bucket, filePath, cwd) {
   let fullFilePath = path.join(cwd, filePath);
   
   var existingFile = new db.File({path: `/${bucket}/${filePath}`})
-  
+
   return existingFile.loadMetadata().catch(() => {
     return false
   }).then((exists) => {
     let stat = fs.statSync(fullFilePath);
-    if (!exists || stat.size < MAX_INCREMENTAL_UPLOAD_SIZE && getFileHash(fullFilePath) !== existingFile.eTag){      
+    if (!exists || stat.size >= MAX_INCREMENTAL_UPLOAD_SIZE || getFileHash(fullFilePath) !== existingFile.eTag){      
       let file = new db.File({path: `/${bucket}/${filePath}`, data: fs.createReadStream(fullFilePath), size: stat.size, type: 'stream'});
       return file.upload({ force: true }).catch(function(e) {
         throw new Error(`Failed to upload file ${filePath}: ${e.message}`);

--- a/cli/deploy.js
+++ b/cli/deploy.js
@@ -10,7 +10,6 @@ const crypto = require('crypto');
 const { default: db } = require('baqend');
 const { SlowBuffer } = require('buffer');
 
-
 let IS_TTY = process.stdout.isTTY;
 
 module.exports = function(args) {
@@ -274,7 +273,7 @@ function upload (db, bucket, files, cwd, uploadLimit) {
         readline.clearLine(process.stdout, 0);
         readline.cursorTo(process.stdout, 0);
       }
-      process.stdout.write(`Uploading file ${(Math.ceil(progress * totalCount))} of ${totalCount}`);
+      IS_TTY && process.stdout.write(`Uploading file ${(Math.ceil(progress * totalCount))} of ${totalCount}`);
       if (IS_TTY && progress === 1) {
           console.log(''); //add a final linebreak
       }
@@ -296,7 +295,7 @@ function cleanUpBucket ({result, existFileMapping})  {
       readline.clearLine(process.stdout, 0);
       readline.cursorTo(process.stdout, 0);
     }
-    process.stdout.write(`Deleting file ${(Math.ceil(progress * totalCount))} of ${totalCount}`);
+    IS_TTY && process.stdout.write(`Deleting file ${(Math.ceil(progress * totalCount))} of ${totalCount}`);
     if (IS_TTY && progress === 1) {
         console.log(''); //add a final linebreak
     }

--- a/cli/deploy.js
+++ b/cli/deploy.js
@@ -178,16 +178,16 @@ function uploadFiles(db, bucket, files, cwd) {
 const MAX_INCREMENTAL_UPLOAD_SIZE = 5242880;
 
 function uploadFile(db, bucket, filePath, cwd) {
-  let fullFilePath = path.join(cwd, filePath);
+  const fullFilePath = path.join(cwd, filePath);
   
-  var existingFile = new db.File({path: `/${bucket}/${filePath}`})
+  const existingFile = new db.File({path: `/${bucket}/${filePath}`})
 
   return existingFile.loadMetadata().catch(() => {
     return false
   }).then((exists) => {
-    let stat = fs.statSync(fullFilePath);
+    const stat = fs.statSync(fullFilePath);
     if (!exists || stat.size >= MAX_INCREMENTAL_UPLOAD_SIZE || getFileHash(fullFilePath) !== existingFile.eTag){      
-      let file = new db.File({path: `/${bucket}/${filePath}`, data: fs.createReadStream(fullFilePath), size: stat.size, type: 'stream'});
+      const file = new db.File({path: `/${bucket}/${filePath}`, data: fs.createReadStream(fullFilePath), size: stat.size, type: 'stream'});
       return file.upload({ force: true }).catch(function(e) {
         throw new Error(`Failed to upload file ${filePath}: ${e.message}`);
       });  

--- a/cli/deploy.js
+++ b/cli/deploy.js
@@ -221,26 +221,19 @@ function upload (db, bucket, files, cwd) {
       console.log(`Uploading ${files.length} files.`)
     }
     const totalCount = files.length;
-    return runGenerator(Generator(files, function (filePath, progress){    
-          
+    return runGenerator(Generator(files, function (filePath, progress) {    
       if (progress > 0) {
         readline.clearLine(process.stdout, 0);
         readline.cursorTo(process.stdout, 0);
       }
-      // process.stdout.write(`Uploading files ${(Math.round(progress * 100))}%`);
       process.stdout.write(`Uploading file ${(Math.ceil(progress * totalCount))} of ${totalCount}`);
-
       if (IS_TTY && progress === 1) {
           console.log(''); //add a final linebreak
       }
-
       return uploadFile(db, bucket, filePath, cwd, existFileMapping).then(() => existFileMapping);
-
-
     })).then((result) => ({result, existFileMapping}))
   }
 }
-
 
 function cleanUp ({result, existFileMapping})  {
   const files = Array.from(existFileMapping.path.values());
@@ -249,12 +242,13 @@ function cleanUp ({result, existFileMapping})  {
     console.log(`Deleting ${files.length} files.`)
   }
 
-  return runGenerator(Generator(files, function (file, progress){    
+  const totalCount = files.length;
+  return runGenerator(Generator(files, function (file, progress) {    
     if (progress > 0) {
       readline.clearLine(process.stdout, 0);
       readline.cursorTo(process.stdout, 0);
     }
-    process.stdout.write(`Deleting files ${(Math.round(progress * 100))}%`);
+    process.stdout.write(`Deleting file ${(Math.ceil(progress * totalCount))} of ${totalCount}`);
     if (IS_TTY && progress === 1) {
         console.log(''); //add a final linebreak
     }
@@ -286,22 +280,6 @@ function uploadFile(db, bucket, filePath, cwd, existFileMapping) {
 function getFileHash(filepath) {
   return crypto.createHash('md5').update(fs.readFileSync(filepath)).digest("hex");
 }
-
-
-
-function runGenerator(generator, parallel = 2, totalResults = []){
-  return Promise.all(
-    Array(parallel).fill(() => Promise.resolve(generator.next().value || [])).map((next) => next())
-  ).then(results => {
-    results = [].concat.apply([],results);
-    totalResults.push(...results)  
-    if (results.length > 0){
-      return runGenerator(generator, parallel, totalResults)
-    }
-    return totalResults;
-  });
-}
-
 
 // Generator
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -55,7 +55,6 @@ if (!module.parent) {
   program
       .command('deploy [app]')
       .description('Deploys your Baqend code and files')
-      .option('-cu, --clean-up',                'Remove all unused files in bucket path')
       .option('-F, --files',                'deploy files')
       .option('-f, --file-dir <dir>',       'path to file directory [default: www]', 'www')
       .option('-g, --file-glob <pattern>',  'pattern to match files [default: **/*]', '**/*')
@@ -63,6 +62,8 @@ if (!module.parent) {
       .option('-C, --code',                 'deploy code')
       .option('-c, --code-dir <dir>',       'path to code directory [default: baqend]', 'baqend')
       .option('-S, --schema',               'deploy schema')
+      .option('--upload-limit <count>',     'Set parallel file upload limit [default: 2]', '2')
+      .option('--clean-up',                 'Remove all unused files in bucket path')
       .action((app, options) => result = deploy(Object.assign({ app: app }, options)))
   ;
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -55,6 +55,7 @@ if (!module.parent) {
   program
       .command('deploy [app]')
       .description('Deploys your Baqend code and files')
+      .option('-cu, --clean-up',                'Remove all unused files in bucket path')
       .option('-F, --files',                'deploy files')
       .option('-f, --file-dir <dir>',       'path to file directory [default: www]', 'www')
       .option('-g, --file-glob <pattern>',  'pattern to match files [default: **/*]', '**/*')

--- a/lib/binding/File.js
+++ b/lib/binding/File.js
@@ -530,17 +530,15 @@ class File {
    */
   setDataOptions(options) {
     const data = options.data;
-    const type = options.type;
 
-    if (!data) {
-      return;
+    if (data) {
+      const type = options.type;
+      // Set data
+      this[DATA] = { type, data };
     }
-
-    // Set data
-    this[DATA] = { type, data };
-
+    
     const mimeType = this.guessMimeType(options);
-    this.fromJSON(Object.assign({}, options, { mimeType }));
+    this.fromJSON(Object.assign({}, options, { mimeType, eTag: options.eTag }));
   }
 
   /**
@@ -608,15 +606,15 @@ class File {
         acl.fromJSON(json.acl);
       }
     }
-
+    
     // keep last known lastModified, createdAt, eTag and headers
-    this[METADATA] = Object.assign({}, this[METADATA], {
-      mimeType: json.mimeType,
+    this[METADATA] = Object.assign({}, meta, {
+      mimeType: json.mimeType || meta.mimeType,
       lastModified: (json.lastModified && new Date(json.lastModified)) || meta.lastModified,
       createdAt: (json.createdAt && new Date(json.createdAt)) || meta.createdAt,
       eTag: json.eTag || meta.eTag,
       acl,
-      size: typeof json.size === 'number' ? json.size : json.contentLength,
+      size: (typeof json.size === 'number' ? json.size : json.contentLength) || meta.size,
       headers: json.headers || meta.headers || {},
     });
   }


### PR DESCRIPTION
Hello

Would have an adaptation for the Deploy CLI process.

Background was that I have a website where I upload up to 4000 files with each deployment.

The upload now, is suitable for the case with `< 1000` files.
With large amounts of data, many files are uploaded unnecessarily and consume the app quota (e.g. requests).

With the change from the PR there will be incremental upload. 
Initially we will check which files have to be uploaded at all.

**Important:** For the incremental upload the `eTag` and `lastModified` of the file objects will be used. Here it was missing the storage of both properties in the file `lib/binding/File.js`, if files were retrieved via `listFiles`.

There are two new options for the 'deploy' command.

### --clean-up

If the `--clean-up` option is set, all unused files are removed from the bucket. Ideal for static pages where an HTML file disappears 🙃

### --upload-limit

With the option `--upload-limit` the number of parallel uploads can be defined. Default is `2`.